### PR TITLE
chore(ci): migrate notion_pr_sync.yml to GITHUB_TOKEN [SEC-58]

### DIFF
--- a/.github/workflows/notion_pr_sync.yml
+++ b/.github/workflows/notion_pr_sync.yml
@@ -1,0 +1,62 @@
+name: Notion PR Sync
+
+on:
+  issues:
+    types:
+      [
+        opened,
+        edited,
+        deleted,
+        transferred,
+        pinned,
+        unpinned,
+        closed,
+        reopened,
+        assigned,
+        unassigned,
+        labeled,
+        unlabeled,
+        locked,
+        unlocked,
+        milestoned,
+        demilestoned,
+      ]
+  pull_request:
+    types:
+      [
+        assigned,
+        unassigned,
+        labeled,
+        unlabeled,
+        opened,
+        edited,
+        closed,
+        reopened,
+        synchronize,
+        converted_to_draft,
+        ready_for_review,
+        locked,
+        unlocked,
+        review_requested,
+        review_request_removed,
+        auto_merge_enabled,
+        auto_merge_disabled,
+      ]
+
+jobs:
+  request:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Sync Github PRs to Notion
+        uses: sivashanmukh/github-notion-pr-sync@3967330238449a8550b06f6e1d6b83e1af569876 # 1.0.0
+        with:
+          notionKey: ${{ secrets.NOTION_BOT_KEY }}
+          notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces secrets.PAT with secrets.GITHUB_TOKEN for Notion PR sync
- Adds explicit pull-requests: read permission with comment explaining why

## Test plan
- [ ] Verify PR sync still works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)